### PR TITLE
Add X-GM-RAW support for search

### DIFF
--- a/lib/search-compiler.js
+++ b/lib/search-compiler.js
@@ -117,6 +117,11 @@ module.exports.searchCompiler = (connection, query) => {
                         setOpt(attributes, 'X-GM-THRID', params[term]);
                     }
                     break;
+                case 'GMRAW':
+                    if (connection.capabilities.has('X-GM-EXT-1')) {
+                        setOpt(attributes, 'X-GM-RAW', params[term]);
+                    }
+                    break;
 
                 case 'BEFORE':
                 case 'ON':


### PR DESCRIPTION
Add support for Gmail IMAP extensions command X-GM-RAW via gmRaw key in the search query
Documentation: https://developers.google.com/gmail/imap/imap-extensions#extension_of_the_search_command_x-gm-raw