### PR TITLE
Add expectedSize to DownloadObject typedef

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -2163,6 +2163,7 @@ class ImapFlow extends EventEmitter {
      * @typedef {Object} DownloadObject
      * @global
      * @property {Object} meta content metadata
+     * @property {number} meta.expectedSize The fetch response size
      * @property {String} meta.contentType Content-Type of the streamed file. If part was not set then this value is "message/rfc822"
      * @property {String} [meta.charset] Charset of the body part. Text parts are automaticaly converted to UTF-8, attachments are kept as is
      * @property {String} [meta.disposition] Content-Disposition of the streamed file


### PR DESCRIPTION
The download method will set an expectedSize property in DownloadObject meta data, but this was not indicated in JSDoc typedef.  This pull request simply updates the typedef to add the expectedSize property.