### PR TITLE
fixed type error in optional parameter of list() method

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -1474,6 +1474,7 @@ class ImapFlow extends EventEmitter {
      * list.forEach(mailbox=>console.log(mailbox.path));
      */
     async list(options) {
+        options = options || {};
         let folders = await this.run('LIST', '', '*', options);
         this.folders = new Map(folders.map(folder => [folder.path, folder]));
         return folders;


### PR DESCRIPTION
Fixed typescript issues while using optional parameters in list() method.
-> Initialized the paramaters with empty object by default
