### PR TITLE
mention logger option, `false`

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -123,7 +123,7 @@ class ImapFlow extends EventEmitter {
      * @param {Boolean} [options.tls.rejectUnauthorized=true] if `false` then client accepts self-signed and expired certificates from the server
      * @param {String} [options.tls.minVersion=TLSv1.2] To improvde security you might need to use something newer, eg *'TLSv1.2'*
      * @param {Number} [options.tls.minDHSize=1024] Minimum size of the DH parameter in bits to accept a TLS connection
-     * @param {Object} [options.logger] Custom logger instance with `debug(obj)`, `info(obj)`, `warn(obj)` and `error(obj)` methods. If not provided then ImapFlow logs to console using pino format
+     * @param {Object} [options.logger] Custom logger instance with `debug(obj)`, `info(obj)`, `warn(obj)` and `error(obj)` methods. If not provided then ImapFlow logs to console using pino format. Can be disabled by setting to `false`
      * @param {Boolean} [options.logRaw=false] If true then log data read from and written to socket encoded in base64
      * @param {Boolean} [options.emitLogs=false] If `true` then in addition of sending data to logger, ImapFlow emits 'log' events with the same data
      * @param {Boolean} [options.verifyOnly=false] If `true` then logs out automatically after successful authentication


### PR DESCRIPTION
The logger can be disabled by setting to `false`. This functionality is already present, but undocumented, so this is just a documentation edit.

See for example: https://github.com/postalsys/imapflow/issues/18#issuecomment-1271541035