### PR TITLE
fix: add "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.158",
     "description": "IMAP Client for Node",
     "main": "./lib/imap-flow.js",
+    "types": "./lib/types.d.ts",
     "scripts": {
         "test": "grunt",
         "prepare": "npm run build",


### PR DESCRIPTION
TypeScript won't find the types unless you tell it where they are.