### PR TITLE
Remove a dollar sign before the npm install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Source code is available from [Github](https://github.com/postalsys/imapflow).
 First install the module from npm:
 
 ```
-$ npm install imapflow
+npm install imapflow
 ```
 
 next import the ImapFlow class into your script:


### PR DESCRIPTION
# Problem

TLDR: Blind copy-pasting the `$ npm install imapflow` command doesn't work because of the leading dollar sign.

When reading the README.md on the main GitHub repository page, they provide a button to copy the content of the code block.

My workflow is to click this button and then paste the result elsewhere - in this case to the terminal.

Since the code block contains a dollar sign in the beginning, I can't just copy and paste the command. Instead, I will get an error `command not found: $`.

# Solution

Remove the dollar sign from the beginning of `$ npm install imapflow`. This way, copy-pasting will work as expected.

The only possible downside is that it might decrease readability a bit, but nothing serious.