### PR TITLE
Ensure `destroySoon()` is not called if is not a function

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -768,7 +768,11 @@ class ImapFlow extends EventEmitter {
         this.writeSocket.destroySoon = () => {
             try {
                 if (this.socket) {
-                    this.socket.destroySoon();
+                    if (typeof this.socket.destroySoon === "function") {
+                        this.socket.destroySoon();
+                    } else {
+                        this.socket.destroy();
+                    }
                 }
                 this.writeSocket.end();
             } catch (err) {
@@ -1480,7 +1484,11 @@ class ImapFlow extends EventEmitter {
 
         if (this.writeSocket && !this.writeSocket.destroyed) {
             try {
-                this.writeSocket.destroySoon();
+                if (typeof this.writeSocket.destroySoon === "function") {
+                    this.writeSocket.destroySoon();
+                } else {
+                    this.writeSocket.destroy();
+                }
             } catch (err) {
                 this.log.error({ err, cid: this.id });
             }
@@ -1488,7 +1496,11 @@ class ImapFlow extends EventEmitter {
 
         if (this.socket && !this.socket.destroyed && this.writeSocket !== this.socket) {
             try {
-                this.socket.destroySoon();
+                if (typeof this.socket.destroySoon === "function") {
+                    this.socket.destroySoon();
+                } else {
+                    this.socket.destroy();
+                }
             } catch (err) {
                 this.log.error({ err, cid: this.id });
             }


### PR DESCRIPTION
When `options.secure = true`, `tls` is used, which `exports.connect = _tls_wrap.connect;`, which returns `TLSSocket`, which doesn't have `destroySoon()`.

This PR simply adds some check to make sure that if `destroySoon` is not a function, `destroy()` is called instead, which is common to both `tls` and `net`.