### PR TITLE
Add status to folderTree when option is present

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -147,6 +147,8 @@ module.exports = {
                 existing.path = folder.path;
                 existing.subscribed = !!folder.subscribed;
                 existing.listed = !!folder.listed;
+                existing.status = !!folder.status;
+
                 if (folder.specialUse) {
                     existing.specialUse = folder.specialUse;
                 }
@@ -164,7 +166,8 @@ module.exports = {
                     flags: folder.flags,
                     path: folder.path,
                     subscribed: !!folder.subscribed,
-                    listed: !!folder.listed
+                    listed: !!folder.listed,
+                    status: !!folder.status
                 };
 
                 if (folder.delimiter) {


### PR DESCRIPTION
The options object is now present at the listTree function but the status object is still missing in the response. This is due to the getFolderTree function ignoring it. Thank you for the fast response.