### PR TITLE
Add `fetchAll` method

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -2353,6 +2353,36 @@ class ImapFlow extends EventEmitter {
     }
 
     /**
+     * Fetch messages from currently opened mailbox
+     * This will fetch all messages before resolving the promise, unlike .fetch() which is async generator
+     *
+     * @param {SequenceString | Number[] | SearchObject} range Range of messages to fetch
+     * @param {FetchQueryObject} query Fetch query
+     * @param {Object} [options]
+     * @param {Boolean} [options.uid] If `true` then uses UID numbers instead of sequence numbers for `range`
+     * @param {BigInt} [options.changedSince] If set then only messages with a higher modseq value are returned. Ignored if server does not support `CONDSTORE` extension.
+     * @param {Boolean} [options.binary=false] If `true` then requests a binary response if the server supports this
+     * @returns {Promise<FetchMessageObject[]>} Array of Message data object
+     *
+     * @example
+     * let mailbox = await client.mailboxOpen('INBOX');
+     * // fetch UID for all messages in a mailbox
+     * const messages = await client.fetchAll('1:*', {uid: true});
+     * for (let msg of messages){
+     *     console.log(msg.uid);
+     *     // You can not run any IMAP commands in this loop
+     * }
+     */
+    async fetchAll(range, query, options) {
+        const results = [];
+        const generator = this.fetch(range, query, options);
+        for await (const message of generator) {
+            results.push(message);
+        }
+        return results;
+    }
+
+    /**
      * Fetch a single message from currently opened mailbox
      *
      * @param {SequenceString} seq Single UID or sequence number of the message to fetch for


### PR DESCRIPTION
Adds a new `fetchAll` public method.

`fetchAll` just calls `fetch` but will drain the async generator and return an array of results.

It appears users commonly hit the issue with this library where they are unable to make IMAP commands while using `fetchAll` not realizing that it causes a deadlock. Without the library automatically detecting misusage like this, time will be wasted by developers while they learn about this edge case. Unfortunately a single comment in some example code for the documentation of the `.fetch` function is not enough.

Having a `.fetchAll` method provides an easy to use interface for the library which will help new users and increase library adoption.

Related Issues:
https://github.com/postalsys/imapflow/issues/206
https://github.com/postalsys/imapflow/issues/159
https://github.com/postalsys/imapflow/issues/130
https://github.com/postalsys/imapflow/issues/110