### PR TITLE
Allow to disable STARTTLS

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -133,6 +133,7 @@ class ImapFlow extends EventEmitter {
      * @param {Boolean} [options.tls.rejectUnauthorized=true] if `false` then client accepts self-signed and expired certificates from the server
      * @param {String} [options.tls.minVersion=TLSv1.2] To improvde security you might need to use something newer, eg *'TLSv1.2'*
      * @param {Number} [options.tls.minDHSize=1024] Minimum size of the DH parameter in bits to accept a TLS connection
+     * @param {Boolean} [options.tls.disableSTARTTLS=false] if `true`, do not use STARTTLS, even if the server advertizes it in CAPABILITIES. This helps with servers that have a broken TLS configuration. If `secure == false`, too, then use a plain unencrypted socket.
      * @param {Object} [options.logger] Custom logger instance with `debug(obj)`, `info(obj)`, `warn(obj)` and `error(obj)` methods. If not provided then ImapFlow logs to console using pino format. Can be disabled by setting to `false`
      * @param {Boolean} [options.logRaw=false] If true then log data read from and written to socket encoded in base64
      * @param {Boolean} [options.emitLogs=false] If `true` then in addition of sending data to logger, ImapFlow emits 'log' events with the same data
@@ -843,7 +844,7 @@ class ImapFlow extends EventEmitter {
             return true;
         }
 
-        if (!this.capabilities.has('STARTTLS')) {
+        if (!this.capabilities.has('STARTTLS') || this.options.tls?.disableSTARTTLS) {
             // can not upgrade
             return false;
         }


### PR DESCRIPTION
Some servers are misconfigured and advertize `STARTTLS` in IMAP `CAPABILITY`, but it doesn't actually work. This is actually the default configuration for some popular mail servers like Dovecot: SSL is enabled by default, but the certificates are not set up properly (never created, paths not set correctly in config file, wrong format or outdated ciphers). For Dovecot, it appears that the default config is exactly that. In any case, no matter why, I have such a server here.

### Reproduction
1. Server with `* OK [CAPABILITY IMAP4rev1 STARTTLS]` and no certificate set up
2. Configure ImapFlow connection to use neither SSL nor STARTTLS:
```
      let options = {
        host: hostname,
        port: 143,
        auth: { ... },
        secure: false,
        tls: {
          disableSTARTTLS: true,
        },
      }
      let connection = await appGlobal.remoteApp.createIMAPFlowConnection(options);
```
3. Connect and authenticate

### Actual result
* A popup dialog shows up, from node.js, outside the app UI, which says `OPENSSL_internal:WRONG_VERSION_NUMBER`

![image](https://github.com/user-attachments/assets/8038b7c4-bf3a-4b8d-b7c6-af8ffe49cce9)

### Expected result
* (The email app warns the user that this configuration is insecure. But it may be OK in some cases, e.g. on a local network, for testing, or for servers which simply don't work with any other configuration.)
* No error
* IMAP connection and authentication works

### Security
* STARTTLS for opportunistic encryption (meaning: Use it when it's there, otherwise connect without it) is now considered insecure and dangerous, because it gives a false sense of security. See e.g. the FOSDEM talk Feb 2024 about it, and lots of research papers referenced there.
* Thunderbird and my email client only offers the 3 modes:
  * 1. Always direct/implement TLS (default)
  * 2. Always STARTTLS (legacy servers only)
  * 3. Never TLS (with a big fat red warning; if nothing else works)

### Fix
* This PR introduces a new connection option, in the `tls` section, where I can also enable old TLS versions or accept broken certificates.
* `options.tls.disableSTARTTLS = true` skips the attempt to change to `STARTTLS`.
* This allows me to connect to the IMAP server