### PR TITLE
Prefer AUTH PLAIN over AUTH LOGIN

### DIFF
--- a/lib/commands/authenticate.js
+++ b/lib/commands/authenticate.js
@@ -151,12 +151,11 @@ module.exports = async (connection, username, { accessToken, password }) => {
     }
 
     if (password) {
-        if (connection.capabilities.has('AUTH=LOGIN')) {
-            return await authLogin(connection, username, password);
-        }
-
         if (connection.capabilities.has('AUTH=PLAIN')) {
             return await authPlain(connection, username, password);
+        }
+        if (connection.capabilities.has('AUTH=LOGIN')) {
+            return await authLogin(connection, username, password);
         }
     }
 


### PR DESCRIPTION
### Reproduction
* Connect to a server that has the old IMAP login disabled, and has both SASL `AUTH=PLAIN` and `AUTH=LOGIN` as `CAPABILITY`

### Actual result
* SASL `LOGIN` is used

### Expected result
* SASL `PLAIN` is used

### Reason
* SASL `PLAIN` is defined by [RFC 2595 Section 6](https://www.rfc-editor.org/rfc/rfc2595), updated in [RFC 4616](https://www.rfc-editor.org/rfc/rfc4616) and mentioned in [RFC 4422](https://www.rfc-editor.org/rfc/rfc4422)
* While often implemented, I could not find an RFC for SASL `LOGIN` mechanism.
* Most implementation that I know that implement `LOGIN` also implement `PLAIN` (and in any case, the code as proposed will fall back to it).
* `LOGIN` is a 2-step mechanism, with 2 round-trips, whereas `PLAIN` is a single step mechanism with only 1 round-trip, so `PLAIN` is faster.

-> `PLAIN` is a) the official standard and b) faster and c) widely implemented. It merits to be the default.
