### PR TITLE
Fix messageFlagsSet with empty flag array

### DIFF
--- a/lib/commands/store.js
+++ b/lib/commands/store.js
@@ -46,7 +46,7 @@ module.exports = async (connection, range, flags, options) => {
         })
         .filter(flag => flag);
 
-    if (!flags.length && operation !== 'set') {
+    if (!flags.length && options.operation !== 'set') {
         // nothing to do here
         return false;
     }


### PR DESCRIPTION
We avoid unnecessary IMAP commands if the flag array is empty *AND* we are either adding or removing flags (this is a no-op). This short-circuit should not be in place when we are *setting* flags.

The logic for this is currently in-place but broken. We are checking if operation !== 'set'. However, the operation variable will equal "FLAGS". We should be checking the options.operation variable instead.