### PR TITLE
Date time format in IMAP requires space before a single digit - fixes #271

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -780,7 +780,7 @@ const tools = {
             return;
         }
 
-        let dateStr = tools.formatDate(value).replace(/^0/, ''); //starts with date-day-fixed with leading 0 replaced by SP
+        let dateStr = tools.formatDate(value).replace(/^0/, ' '); //starts with date-day-fixed with leading 0 replaced by SP
         let timeStr = value.toISOString().substr(11, 8);
 
         return `${dateStr} ${timeStr} +0000`;


### PR DESCRIPTION
https://www.xmox.nl/xr/dev/rfc/9051.html#L6502
https://www.xmox.nl/xr/dev/rfc/3501.html#L4713