### PR TITLE
Authentication: Report errors; Fix LOGINDISABLED

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -1067,6 +1067,8 @@ class ImapFlow extends EventEmitter {
                 }
                 this.authenticated = await this.run('LOGIN', this.options.auth.user, this.options.auth.pass);
             }
+        } else {
+            throw new AuthenticationFailure('No password configured');
         }
 
         if (this.authenticated) {

--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -796,11 +796,7 @@ class ImapFlow extends EventEmitter {
 
         await this.upgradeToSTARTTLS();
 
-        let authenticated = await this.authenticate();
-        if (!authenticated) {
-            // nothing to do here
-            return await this.logout();
-        }
+        await this.authenticate();
 
         if (!this.idRequested && this.capabilities.has('ID')) {
             // re-request ID after LOGIN
@@ -812,8 +808,7 @@ class ImapFlow extends EventEmitter {
         if (nsResponse && nsResponse.error && nsResponse.status === 'BAD' && /User is authenticated but not connected/i.test(nsResponse.text)) {
             // Not a NAMESPACE failure but authentication failure, so report as
             this.authenticated = false;
-            let err = new Error('Authentication failed');
-            err.authenticationFailed = true;
+            let err = new AuthenticationFailure('Authentication failed');
             err.response = nsResponse.text;
             throw err;
         }
@@ -1048,9 +1043,8 @@ class ImapFlow extends EventEmitter {
             return this.state !== this.states.LOGOUT;
         }
 
-        if (this.capabilities.has('LOGINDISABLED') || !this.options.auth) {
-            // can not log in
-            return false;
+        if (!this.options.auth) {
+            throw new AuthenticationFailure('Please configure the login');
         }
 
         this.expectCapabilityUpdate = true;
@@ -1067,6 +1061,9 @@ class ImapFlow extends EventEmitter {
             if ((this.capabilities.has('AUTH=LOGIN') || this.capabilities.has('AUTH=PLAIN')) && loginMethod !== 'LOGIN') {
                 this.authenticated = await this.run('AUTHENTICATE', this.options.auth.user, { password: this.options.auth.pass, loginMethod });
             } else {
+                if (this.capabilities.has('LOGINDISABLED')) {
+                    throw new AuthenticationFailure('Login is disabled');
+                }
                 this.authenticated = await this.run('LOGIN', this.options.auth.user, this.options.auth.pass);
             }
         }
@@ -1082,7 +1079,7 @@ class ImapFlow extends EventEmitter {
             return true;
         }
 
-        return false;
+        throw new AuthenticationFailure('No matching authentication method');
     }
 
     async initialOK(message) {
@@ -3225,6 +3222,10 @@ class ImapFlow extends EventEmitter {
             writeSocket: this.writeSocket || this.socket
         };
     }
+}
+
+class AuthenticationFailure extends Error {
+    authenticationFailed = true;
 }
 
 /**

--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -38,6 +38,7 @@ const {
     packMessageRange,
     normalizePath,
     expandRange,
+    AuthenticationFailure,
     getColorFlags
 } = require('./tools');
 
@@ -3222,10 +3223,6 @@ class ImapFlow extends EventEmitter {
             writeSocket: this.writeSocket || this.socket
         };
     }
-}
-
-class AuthenticationFailure extends Error {
-    authenticationFailed = true;
 }
 
 /**

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -94,7 +94,7 @@ const tools = {
         return map;
     },
 
-    AuthenticationFailure: AuthenticationFailure,
+    AuthenticationFailure,
 
     getStatusCode(response) {
         return response &&

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -11,6 +11,10 @@ const iconv = require('iconv-lite');
 
 const FLAG_COLORS = ['red', 'orange', 'yellow', 'green', 'blue', 'purple', 'grey'];
 
+class AuthenticationFailure extends Error {
+    authenticationFailed = true;
+}
+
 const tools = {
     encodePath(connection, path) {
         path = (path || '').toString();
@@ -89,6 +93,8 @@ const tools = {
 
         return map;
     },
+
+    AuthenticationFailure: AuthenticationFailure,
 
     getStatusCode(response) {
         return response &&


### PR DESCRIPTION
1. `LOGINDISABLED`

The `LOGINDISABLED` capability only disables the legacy IMAP `LOGIN` command, and does *not* disable all login, and does *not* disable the `AUTHENTICATE` command for SASL auth, but instead forces a client to use one of the advertized SASL mechanisms, including `AUTH=PLAIN`, or upgrade to `STARTTLS`.

If there is `LOGINDISABLED` capa and no `AUTH=` capas, then login is disabled. (If there is the `STARTTLS` capa, login may be enabled after STARTTLS is completed.)

https://www.rfc-editor.org/rfc/rfc2595#section-3.2
https://www.rfc-editor.org/rfc/rfc3501#section-7.2.1

2. Auth error reporting

If the client does not configure a password (`options.auth.pass` is empty), then imapflow will simply logout immediately after CAPA, without any error, nor any indication about what's wrong. The client will only see a closed collection immediately before auth, and the server the same. This is difficult to debug. Instead, imapflow should return an error message about what the problem is.

This change throws exceptions with error messages in these cases.

The old code did an explicit immediate logout. This caused the "Unexpected close" error to override the authentication error message. That's why the explicit logout is removed. The behavior should nonetheless almost identical to before, because the exception will throw into the caller of `startSession()`. Both callers report the error and then call `close()`, but after `setImmediate()`, presumably to work around this very problem of overriding error messages. `close()` also sets the state to `LOGOUT`, so the effect should be the same.