### PR TITLE
Catch errors in callback functions

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -364,11 +364,12 @@ class ImapFlow extends EventEmitter {
         this.streamer.on('error', err => {
             if (['Z_BUF_ERROR', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EHOSTUNREACH'].includes(err.code)) {
                 // just close the connection, usually nothing but noise
-                return setImmediate(() => this.close());
+                this.closeAfter();
+                return;
             }
 
             this.log.error({ err, cid: this.id });
-            setImmediate(() => this.close());
+            this.closeAfter();
             this.emitError(err);
         });
 
@@ -742,19 +743,11 @@ class ImapFlow extends EventEmitter {
             this._socketError ||
             (err => {
                 this.log.error({ err, cid: this.id });
-                setImmediate(() => this.close());
+                this.closeAfter();
                 this.emitError(err);
             });
-        this._socketClose =
-            this._socketClose ||
-            (() => {
-                this.close();
-            });
-        this._socketEnd =
-            this._socketEnd ||
-            (() => {
-                this.close();
-            });
+        this._socketClose = this._socketClose || (() => this.close());
+        this._socketEnd = this._socketEnd || (() => this.close());
 
         this._socketTimeout =
             this._socketTimeout ||
@@ -880,21 +873,26 @@ class ImapFlow extends EventEmitter {
         // use normal pipes for this.writeSocket -> this._deflate -> this.socket
         let reading = false;
         let readNext = () => {
-            reading = true;
+            try {
+                reading = true;
 
-            let chunk;
-            while ((chunk = this.writeSocket.read()) !== null) {
-                if (this._deflate && this._deflate.write(chunk) === false) {
-                    return this._deflate.once('drain', readNext);
+                let chunk;
+                while ((chunk = this.writeSocket.read()) !== null) {
+                    if (this._deflate && this._deflate.write(chunk) === false) {
+                        return this._deflate.once('drain', readNext);
+                    }
                 }
-            }
 
-            // flush data to socket
-            if (this._deflate) {
-                this._deflate.flush();
-            }
+                // flush data to socket
+                if (this._deflate) {
+                    this._deflate.flush();
+                }
 
-            reading = false;
+                reading = false;
+            } catch(ex) {
+                this.emitError(ex);
+                this.closeAfter();
+            }
         };
 
         this.writeSocket.on('readable', () => {
@@ -975,7 +973,7 @@ class ImapFlow extends EventEmitter {
                     // don't care anymore
                     return;
                 }
-                setImmediate(() => this.close());
+                this.closeAfter();
                 this.upgrading = false;
                 err.tlsFailed = true;
                 reject(err);
@@ -985,7 +983,7 @@ class ImapFlow extends EventEmitter {
                 if (!this.upgrading) {
                     return;
                 }
-                setImmediate(() => this.close());
+                this.closeAfter();
                 let err = new Error('Failed to upgrade connection in required time');
                 err.tlsFailed = true;
                 err.code = 'UPGRADE_TIMEOUT';
@@ -994,30 +992,35 @@ class ImapFlow extends EventEmitter {
 
             this.upgrading = true;
             this.socket = tls.connect(opts, () => {
-                clearTimeout(this.upgradeTimeout);
-                if (this.isClosed) {
-                    // not sure if this is possible?
-                    return this.close();
-                }
+                try {
+                    clearTimeout(this.upgradeTimeout);
+                    if (this.isClosed) {
+                        // not sure if this is possible?
+                        return this.close();
+                    }
 
-                this.secureConnection = true;
-                this.upgrading = false;
-                this.streamer.secureConnection = true;
-                this.socket.pipe(this.streamer);
-                this.tls = typeof this.socket.getCipher === 'function' ? this.socket.getCipher() : false;
-                if (this.tls) {
-                    this.tls.authorized = this.socket.authorized;
-                    this.log.info({
-                        src: 'tls',
-                        msg: 'Established TLS session',
-                        cid: this.id,
-                        authorized: this.tls.authorized,
-                        algo: this.tls.standardName || this.tls.name,
-                        version: this.tls.version
-                    });
-                }
+                    this.secureConnection = true;
+                    this.upgrading = false;
+                    this.streamer.secureConnection = true;
+                    this.socket.pipe(this.streamer);
+                    this.tls = typeof this.socket.getCipher === 'function' ? this.socket.getCipher() : false;
+                    if (this.tls) {
+                        this.tls.authorized = this.socket.authorized;
+                        this.log.info({
+                            src: 'tls',
+                            msg: 'Established TLS session',
+                            cid: this.id,
+                            authorized: this.tls.authorized,
+                            algo: this.tls.standardName || this.tls.name,
+                            version: this.tls.version
+                        });
+                    }
 
-                return resolve(true);
+                    return resolve(true);
+                } catch (ex) {
+                    this.emitError(ex);
+                    this.closeAfter();
+                }
             });
 
             this.writeSocket = this.socket;
@@ -1128,7 +1131,7 @@ class ImapFlow extends EventEmitter {
                     return reject(err);
                 }
 
-                setImmediate(() => this.close());
+                this.closeAfter();
             });
     }
 
@@ -1164,7 +1167,7 @@ class ImapFlow extends EventEmitter {
                     return reject(err);
                 }
 
-                setImmediate(() => this.close());
+                this.closeAfter();
             });
     }
 
@@ -1467,55 +1470,59 @@ class ImapFlow extends EventEmitter {
                     connectionTimeout: this.options.connectionTimeout || CONNECT_TIMEOUT
                 };
                 this.log.error({ err, cid: this.id });
-                setImmediate(() => this.close());
+                this.closeAfter();
                 reject(err);
             }, this.options.connectionTimeout || CONNECT_TIMEOUT);
 
             let onConnect = () => {
-                clearTimeout(this.connectTimeout);
-                this.socket.setKeepAlive(true, 5 * 1000);
-                this.socket.setTimeout(this.options.socketTimeout || SOCKET_TIMEOUT);
+                try {
+                    clearTimeout(this.connectTimeout);
+                    this.socket.setKeepAlive(true, 5 * 1000);
+                    this.socket.setTimeout(this.options.socketTimeout || SOCKET_TIMEOUT);
 
-                this.greetingTimeout = setTimeout(() => {
-                    let err = new Error(`Failed to receive greeting from server in required time${!this.secureConnection ? '. Maybe should use TLS?' : ''}`);
-                    err.code = 'GREETING_TIMEOUT';
-                    err.details = {
-                        greetingTimeout: this.options.greetingTimeout || GREETING_TIMEOUT
+                    this.greetingTimeout = setTimeout(() => {
+                        let err = new Error(`Failed to receive greeting from server in required time${!this.secureConnection ? '. Maybe should use TLS?' : ''}`);
+                        err.code = 'GREETING_TIMEOUT';
+                        err.details = {
+                            greetingTimeout: this.options.greetingTimeout || GREETING_TIMEOUT
+                        };
+                        this.log.error({ err, cid: this.id });
+                        this.closeAfter();
+                        reject(err);
+                    }, this.options.greetingTimeout || GREETING_TIMEOUT);
+
+                    this.tls = typeof this.socket.getCipher === 'function' ? this.socket.getCipher() : false;
+
+                    let logInfo = {
+                        src: 'connection',
+                        msg: `Established ${this.tls ? 'secure ' : ''}TCP connection`,
+                        cid: this.id,
+                        secure: !!this.tls,
+                        host: this.host,
+                        servername: this.servername,
+                        port: this.socket.remotePort,
+                        address: this.socket.remoteAddress,
+                        localAddress: this.socket.localAddress,
+                        localPort: this.socket.localPort
                     };
-                    this.log.error({ err, cid: this.id });
-                    setImmediate(() => this.close());
-                    reject(err);
-                }, this.options.greetingTimeout || GREETING_TIMEOUT);
 
-                this.tls = typeof this.socket.getCipher === 'function' ? this.socket.getCipher() : false;
+                    if (this.tls) {
+                        logInfo.authorized = this.tls.authorized = this.socket.authorized;
+                        logInfo.algo = this.tls.standardName || this.tls.name;
+                        logInfo.version = this.tls.version;
+                    }
 
-                let logInfo = {
-                    src: 'connection',
-                    msg: `Established ${this.tls ? 'secure ' : ''}TCP connection`,
-                    cid: this.id,
-                    secure: !!this.tls,
-                    host: this.host,
-                    servername: this.servername,
-                    port: this.socket.remotePort,
-                    address: this.socket.remoteAddress,
-                    localAddress: this.socket.localAddress,
-                    localPort: this.socket.localPort
-                };
+                    this.log.info(logInfo);
 
-                if (this.tls) {
-                    logInfo.authorized = this.tls.authorized = this.socket.authorized;
-                    logInfo.algo = this.tls.standardName || this.tls.name;
-                    logInfo.version = this.tls.version;
+                    this.setSocketHandlers();
+                    this.socket.pipe(this.streamer);
+
+                    // executed by initial "* OK"
+                    this.initialResolve = resolve;
+                    this.initialReject = reject;
+                } catch (ex) { // connect failed
+                    reject(ex);
                 }
-
-                this.log.info(logInfo);
-
-                this.setSocketHandlers();
-                this.socket.pipe(this.streamer);
-
-                // executed by initial "* OK"
-                this.initialResolve = resolve;
-                this.initialReject = reject;
             };
 
             if (socket) {
@@ -1538,7 +1545,7 @@ class ImapFlow extends EventEmitter {
             this.socket.on('error', err => {
                 clearTimeout(this.connectTimeout);
                 clearTimeout(this.greetingTimeout);
-                setImmediate(() => this.close());
+                this.closeAfter();
                 this.log.error({ err, cid: this.id });
                 reject(err);
             });
@@ -1562,6 +1569,15 @@ class ImapFlow extends EventEmitter {
     }
 
     /**
+     * Close the TCP connection.
+     * Unlike `close()`, return immediately from this function, allowing the
+     * caller function to proceed, and run `close()` function afterwards.
+     */
+    closeAfter() {
+        setImmediate(() => this.close());
+    }
+
+    /**
      * Closes TCP connection without notifying the server.
      *
      * @example
@@ -1571,79 +1587,84 @@ class ImapFlow extends EventEmitter {
      * client.close();
      */
     close() {
-        // clear pending timers
-        clearTimeout(this.idleStartTimer);
-        clearTimeout(this.upgradeTimeout);
-        clearTimeout(this.connectTimeout);
+        try {
+            // clear pending timers
+            clearTimeout(this.idleStartTimer);
+            clearTimeout(this.upgradeTimeout);
+            clearTimeout(this.connectTimeout);
 
-        this.usable = false;
-        this.idling = false;
+            this.usable = false;
+            this.idling = false;
 
-        if (typeof this.initialReject === 'function' && !this.options.verifyOnly) {
-            clearTimeout(this.greetingTimeout);
-            let reject = this.initialReject;
-            this.initialResolve = false;
-            this.initialReject = false;
-            let err = new Error('Unexpected close');
-            err.code = `ClosedAfterConnect${this.secureConnection ? 'TLS' : 'Text'}`;
-            // still has to go through the logic below
-            setImmediate(() => reject(err));
-        }
-
-        if (typeof this.preCheck === 'function') {
-            this.preCheck().catch(err => this.log.warn({ err, cid: this.id }));
-        }
-
-        // reject command that is currently processed
-        if (this.currentRequest && this.requestTagMap.has(this.currentRequest.tag)) {
-            let request = this.requestTagMap.get(this.currentRequest.tag);
-            if (request) {
-                this.requestTagMap.delete(request.tag);
-                const error = new Error('Connection not available');
-                error.code = 'NoConnection';
-                request.reject(error);
+            if (typeof this.initialReject === 'function' && !this.options.verifyOnly) {
+                clearTimeout(this.greetingTimeout);
+                let reject = this.initialReject;
+                this.initialResolve = false;
+                this.initialReject = false;
+                let err = new Error('Unexpected close');
+                err.code = `ClosedAfterConnect${this.secureConnection ? 'TLS' : 'Text'}`;
+                // still has to go through the logic below
+                setImmediate(() => reject(err));
             }
-            this.currentRequest = false;
-        }
 
-        // reject all other pending commands
-        while (this.requestQueue.length) {
-            let req = this.requestQueue.shift();
-            if (req && this.requestTagMap.has(req.tag)) {
-                let request = this.requestTagMap.get(req.tag);
+            if (typeof this.preCheck === 'function') {
+                this.preCheck().catch(err => this.log.warn({ err, cid: this.id }));
+            }
+
+            // reject command that is currently processed
+            if (this.currentRequest && this.requestTagMap.has(this.currentRequest.tag)) {
+                let request = this.requestTagMap.get(this.currentRequest.tag);
                 if (request) {
                     this.requestTagMap.delete(request.tag);
                     const error = new Error('Connection not available');
                     error.code = 'NoConnection';
                     request.reject(error);
                 }
+                this.currentRequest = false;
             }
-        }
 
-        this.state = this.states.LOGOUT;
-        if (this.isClosed) {
-            return;
-        }
-        this.isClosed = true;
-
-        if (this.writeSocket && !this.writeSocket.destroyed) {
-            try {
-                this.writeSocket.destroy();
-            } catch (err) {
-                this.log.error({ err, cid: this.id });
+            // reject all other pending commands
+            while (this.requestQueue.length) {
+                let req = this.requestQueue.shift();
+                if (req && this.requestTagMap.has(req.tag)) {
+                    let request = this.requestTagMap.get(req.tag);
+                    if (request) {
+                        this.requestTagMap.delete(request.tag);
+                        const error = new Error('Connection not available');
+                        error.code = 'NoConnection';
+                        request.reject(error);
+                    }
+                }
             }
-        }
 
-        if (this.socket && !this.socket.destroyed && this.writeSocket !== this.socket) {
-            try {
-                this.socket.destroy();
-            } catch (err) {
-                this.log.error({ err, cid: this.id });
+            this.state = this.states.LOGOUT;
+            if (this.isClosed) {
+                return;
             }
-        }
+            this.isClosed = true;
 
-        this.log.trace({ msg: 'Connection closed', cid: this.id });
-        this.emit('close');
+            if (this.writeSocket && !this.writeSocket.destroyed) {
+                try {
+                    this.writeSocket.destroy();
+                } catch (err) {
+                    this.log.error({ err, cid: this.id });
+                }
+            }
+
+            if (this.socket && !this.socket.destroyed && this.writeSocket !== this.socket) {
+                try {
+                    this.socket.destroy();
+                } catch (err) {
+                    this.log.error({ err, cid: this.id });
+                }
+            }
+
+            this.log.trace({ msg: 'Connection closed', cid: this.id });
+            this.emit('close');
+        } catch (ex) { // close failed
+            this.emitError(ex); // TODO Just noise? Remove?
+            this.log.error(ex);
+        }
     }
 
     /**
@@ -2850,11 +2871,15 @@ class ImapFlow extends EventEmitter {
             }
         };
 
-        setImmediate(() => {
-            writeChunk(chunk);
-            fetchAllParts()
-                .catch(err => stream.emit('error', err))
-                .finally(() => stream.end());
+        setImmediate(async () => {
+            try {
+                writeChunk(chunk);
+                await fetchAllParts();
+            } catch (ex) {
+                stream.emit('error', ex);
+            } finally {
+                stream.end();
+            }
         });
 
         return {


### PR DESCRIPTION
Tries to fix https://github.com/mustang-im/mustang/issues/734 

This is due to an unhandled exception that is throwing into node.js. We're reading from a socket, and that read fails, and throws an exception, but we are not catching that exception, so it throws into the caller. A lot of this code is in callback functions, which are called by the socket on'connect' or on'read' event handlers, so the error is unhandled, so this fallback UI dialog shows up.

We need to catch the error and send it to the right error handler on the IMAP connection.

This PR is adding try/catch where they are missing, and tweaking the other error handling code.