### PR TITLE
Fix race condition in connection greeting handling

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -1600,9 +1600,16 @@ class ImapFlow extends EventEmitter {
                     this.setSocketHandlers();
                     this.socket.pipe(this.streamer);
 
-                    // executed by initial "* OK"
-                    this.initialResolve = resolve;
-                    this.initialReject = reject;
+                    // If greeting already arrived before onConnect ran (possible with fast servers or proxies),
+                    // resolve immediately instead of storing the callbacks which could remain dangling.
+                    if (this.greeting) {
+                        // "* OK" already received
+                        resolve();
+                    } else {
+                        // executed by initial "* OK"
+                        this.initialResolve = resolve;
+                        this.initialReject = reject;
+                    }
                 } catch (ex) {
                     // connect failed
                     reject(ex);


### PR DESCRIPTION
## Description

This PR fixes a race condition that occurs when using **imapflow** with fast local IMAP servers or when connecting through a **Proxy**. The server may send the `* OK` greeting **before** the client's `onConnect` function is executed, leaving `initialResolve` and `initialReject` callbacks permanently set and causing "Unexpected close" errors when `client.close()` is called later.

## Root Cause

In the current implementation, `initialResolve` and `initialReject` callbacks are assigned **at the end** of `onConnect`. If the server sends the `* OK` response before `onConnect` runs, the handler for the `OK` response executes while these callbacks are still undefined. They are then assigned immediately afterward, remaining permanently set inside the client object.

This issue is more likely to occur when a **Proxy** is used, because the underlying socket connection may be established **before** the `onConnect` function (and the callbacks) are defined.

## Solution

The fix checks whether the server greeting has already been received (`this.greeting` is defined) inside `onConnect`. If it exists, it calls the `resolve` callback immediately instead of assigning it to `this.initialResolve`.



## Testing

- All existing tests pass (281 assertions)
- No regressions detected
- Lint checks pass

## Fixes

Closes #316