### PR TITLE
fix: correct TLS type and add missing 'text' search property

### DIFF
--- a/lib/imap-flow.d.ts
+++ b/lib/imap-flow.d.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { TlsOptions } from 'tls';
+import { ConnectionOptions } from 'tls';
 import { Readable } from 'stream';
 
 export interface ImapFlowOptions {
@@ -31,7 +31,7 @@ export interface ImapFlowOptions {
     /** If true, then do not start IDLE when connection is established */
     disableAutoIdle?: boolean;
     /** Additional TLS options (see Node.js TLS documentation) */
-    tls?: TlsOptions;
+    tls?: ConnectionOptions;
     /** Custom logger instance. Set to false to disable logging */
     logger?: Logger | false;
     /** If true, log data read and written to socket encoded in base64 */
@@ -300,6 +300,8 @@ export interface SearchObject {
     body?: string;
     /** Matches message subject */
     subject?: string;
+    /** Matches any text in headers and body */
+    text?: string;
     /** Matches messages larger than value */
     larger?: number;
     /** Matches messages smaller than value */

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -104,7 +103,6 @@
             "integrity": "sha512-fcdRcWahONYo+JRnJg1/AekOacGvKx12Gu0qXJXFi2WBqQA1i7+O5PaxRB7kxE/Op94dExnCiiar6T09pvdHpA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
                 "eslint-visitor-keys": "^2.1.0",
@@ -2094,7 +2092,6 @@
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -2171,7 +2168,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2500,7 +2496,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2966,7 +2961,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5126,7 +5120,6 @@
             "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -6725,7 +6718,6 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.23.5",
@@ -7182,7 +7174,6 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -7311,7 +7302,6 @@
             ],
             "inBundle": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001565",
                 "electron-to-chromium": "^1.4.601",
@@ -8082,7 +8072,6 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -8695,7 +8684,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary

This PR fixes two TypeScript definition issues:

1. **Wrong TLS type**: ImapFlow was importing `TlsOptions` (server-side) instead of `ConnectionOptions` (client-side), preventing use of client-specific options like `checkServerIdentity`
2. **Missing `text` search**: The `text` search parameter is documented but missing from `SearchObject` TypeScript definitions

## Problem 1: Wrong TLS Type

ImapFlow is a **client** that connects to IMAP servers, but it was using `TlsOptions` which is the **server-side** interface from Node's `tls` module.

**Current (incorrect)**:
```typescript
import { TlsOptions } from 'tls';

export interface ImapFlowOptions {
    tls?: TlsOptions;  // ❌ Server-side, missing client options
}
```

**Impact**: Users cannot use essential client TLS options without type errors:
- `checkServerIdentity` - Custom hostname validation
- `servername` - SNI (Server Name Indication)
- `session` - Session resumption
- `minDHSize` - Minimum DH parameter size

**Current workaround needed**:
```typescript
new ImapFlow({
  tls: {
    checkServerIdentity: () => undefined
  } as any  // ❌ Type assertion required
});
```

## Problem 2: Missing `text` Search

The `text` search parameter is [documented in the ImapFlow search guide](https://imapflow.com/docs/guides/searching) but missing from `SearchObject`:

> `text` - "Any text (searches headers and body)"

**Current workaround needed**:
```typescript
await client.search({ text: "query" } as any, { uid: true });
```

## Solution

1. Changed `TlsOptions` → `ConnectionOptions` for correct client-side TLS typing
2. Added `text?: string` to `SearchObject` interface with proper JSDoc

## After This PR

Users can use proper typing without workarounds:

```typescript
// TLS options work correctly
new ImapFlow({
  tls: {
    checkServerIdentity: () => undefined,  // ✅ No type error
    servername: 'mail.example.com'         // ✅ Works correctly
  }
});

// Text search works correctly
await client.search({ text: "query" }, { uid: true });  // ✅ No type error
```

## Testing

- ✅ Both features already work at runtime (this just fixes the types)
- ✅ TypeScript compiles without errors
- ✅ No breaking changes (purely additive/corrective)
- ✅ Verified against Node.js `tls` module type definitions

## References

- Node.js TLS docs: https://nodejs.org/api/tls.html#tlsconnectoptions-callback
- ImapFlow search guide: https://imapflow.com/docs/guides/searching
- Node.js `@types/node` definitions confirm `ConnectionOptions` is client-side