### PR TITLE
fix: handle NIL delimiter in NAMESPACE response (RFC 2342)

### DIFF
--- a/lib/commands/namespace.js
+++ b/lib/commands/namespace.js
@@ -122,10 +122,19 @@ function getNamsepaceInfo(attribute) {
     }
 
     return attribute
-        .filter(entry => entry.length >= 2 && typeof entry[0].value === 'string' && typeof entry[1].value === 'string')
+        .filter(entry =>
+            // RFC 2342 allows the delimiter to be NIL (null in the parser) when
+            // the namespace has no hierarchy (LuxSci's `("#mhinbox" NIL)` is a
+            // real-world example). Original filter assumed entry[1] is always
+            // an object with a string `.value`, which crashes on null.
+            entry.length >= 2 &&
+            entry[0] && typeof entry[0].value === 'string' &&
+            (entry[1] === null || (entry[1] && (typeof entry[1].value === 'string' || entry[1].value === null)))
+        )
         .map(entry => {
             let prefix = entry[0].value;
-            let delimiter = entry[1].value;
+            // entry[1] may be a literal null (NIL) or an object whose .value is null/string.
+            let delimiter = entry[1] === null ? null : entry[1].value;
 
             // Append the delimiter to the prefix if it doesn't already end with one,
             // so callers can construct full paths by simply concatenating prefix + name.

--- a/test/commands-integration-test.js
+++ b/test/commands-integration-test.js
@@ -6457,6 +6457,124 @@ module.exports['Commands: namespace handles NIL namespaces'] = async test => {
     test.done();
 };
 
+module.exports['Commands: namespace handles NIL delimiter (RFC 2342)'] = async test => {
+    // RFC 2342 §5 explicitly allows the delimiter component of a namespace
+    // entry to be NIL ("a NIL hierarchy delimiter means that no hierarchy
+    // exists"). Servers in the wild do return this shape — for example a
+    // personal section like (("" "/")("#hidden" NIL)). The original
+    // getNamsepaceInfo() filter assumed entry[1] is always an object with
+    // a string `.value`, which crashed with
+    //   TypeError: Cannot read properties of null (reading 'value')
+    // when entry[1] was the literal `null` produced by the parser for NIL.
+    // The crash escaped the untagged handler, leaving
+    // connection.namespaces.personal undefined, which then crashed at
+    // `if (!connection.namespaces.personal[0]) ...` and corrupted
+    // request/response routing for subsequent commands (LIST/SELECT replies
+    // could no longer be matched to a pending promise → silent hang).
+
+    const connection = createMockConnection({
+        state: 2,
+        capabilities: new Map([['NAMESPACE', true]]),
+        exec: async (cmd, args, opts) => {
+            if (opts && opts.untagged && opts.untagged.NAMESPACE) {
+                await opts.untagged.NAMESPACE({
+                    attributes: [
+                        // personal: one normal entry + one NIL-delimiter entry
+                        [
+                            [{ value: '' }, { value: '/' }],
+                            [{ value: '#hidden' }, null]
+                        ],
+                        null,
+                        null
+                    ]
+                });
+            }
+            return { next: () => {} };
+        }
+    });
+
+    const result = await namespaceCommand(connection);
+
+    // Bail out cleanly if the handler crashed (the bug we're testing). Without
+    // this guard, the assertions below would dereference undefined and fatal
+    // the whole nodeunit suite.
+    if (result && result.error) {
+        test.ok(false, 'namespace command returned error sentinel — likely crashed on NIL delimiter');
+        test.done();
+        return;
+    }
+    if (!Array.isArray(connection.namespaces && connection.namespaces.personal)) {
+        test.ok(false, 'connection.namespaces.personal is not an array (handler crashed mid-untagged-callback)');
+        test.done();
+        return;
+    }
+
+    test.equal(connection.namespaces.personal.length, 2, 'both personal entries should be parsed');
+
+    test.equal(connection.namespaces.personal[0].prefix, '');
+    test.equal(connection.namespaces.personal[0].delimiter, '/');
+
+    // NIL-delimiter entry preserved with delimiter:null rather than dropped
+    // silently or crashing the parser.
+    test.equal(connection.namespaces.personal[1].prefix, '#hidden');
+    test.equal(connection.namespaces.personal[1].delimiter, null);
+
+    // Default namespace pointer should still resolve to the first personal
+    // entry (which has a real delimiter), unchanged from pre-bug behavior
+    // for normal servers.
+    test.equal(connection.namespace.prefix, '');
+    test.equal(connection.namespace.delimiter, '/');
+
+    test.done();
+};
+
+module.exports['Commands: namespace handles NIL delimiter as only personal entry'] = async test => {
+    // Edge case: server returns ONLY a NIL-delimiter entry in the personal
+    // section (no normal entry alongside). The default-namespace fallback
+    // at the bottom of the NAMESPACE handler should still produce a usable
+    // connection.namespace and not throw.
+
+    const connection = createMockConnection({
+        state: 2,
+        capabilities: new Map([['NAMESPACE', true]]),
+        exec: async (cmd, args, opts) => {
+            if (opts && opts.untagged && opts.untagged.NAMESPACE) {
+                await opts.untagged.NAMESPACE({
+                    attributes: [
+                        [[{ value: '#hidden' }, null]],
+                        null,
+                        null
+                    ]
+                });
+            }
+            return { next: () => {} };
+        }
+    });
+
+    const result = await namespaceCommand(connection);
+
+    if (result && result.error) {
+        test.ok(false, 'namespace command returned error sentinel — likely crashed on NIL delimiter');
+        test.done();
+        return;
+    }
+    if (!Array.isArray(connection.namespaces && connection.namespaces.personal)) {
+        test.ok(false, 'connection.namespaces.personal is not an array (handler crashed mid-untagged-callback)');
+        test.done();
+        return;
+    }
+
+    test.equal(connection.namespaces.personal.length, 1);
+    test.equal(connection.namespaces.personal[0].prefix, '#hidden');
+    test.equal(connection.namespaces.personal[0].delimiter, null);
+
+    // connection.namespace should be set and usable downstream.
+    test.ok(connection.namespace);
+    test.equal(typeof connection.namespace.prefix, 'string');
+
+    test.done();
+};
+
 module.exports['Commands: namespace handles multiple personal namespaces'] = async test => {
     const connection = createMockConnection({
         state: 2,


### PR DESCRIPTION
## Summary

`getNamsepaceInfo` in `lib/commands/namespace.js` crashes with a `TypeError` when an IMAP server returns a NAMESPACE response containing a NIL delimiter. RFC 2342 §5 explicitly allows this — *"a NIL hierarchy delimiter means that no hierarchy exists"* — and real-world servers do return that shape. For example, a personal section like:

```
* NAMESPACE (("" "/")("#hidden" NIL)) NIL NIL
```

…produces:
```
TypeError: Cannot read properties of null (reading 'value')
    at lib/commands/namespace.js:125
    at Array.filter (<anonymous>)
    at getNamsepaceInfo (lib/commands/namespace.js:125)
    at NAMESPACE (lib/commands/namespace.js:49)
    at ImapFlow.reader (lib/imap-flow.js:713)
```

The throw originates from the filter:

```js
.filter(entry => entry.length >= 2 && typeof entry[0].value === 'string' && typeof entry[1].value === 'string')
```

When the parser encounters NIL it produces a literal `null` in the entry array, so `entry[1].value` throws.

## Why this matters beyond the immediate crash

The throw escapes the untagged handler, so `map.personal` is never assigned. Execution then continues at:

```js
if (!connection.namespaces.personal[0]) {
    connection.namespaces.personal[0] = { prefix: '', delimiter: '.' };
}
```

…which crashes with a second `TypeError` because `connection.namespaces.personal` is undefined. Both errors are caught by the outer `try/catch` and only logged via `connection.log.warn({err, cid})`, so to the caller `connect()` appears to succeed. **But the connection's request/response routing has now been corrupted** — subsequent `LIST` / `SELECT` / etc. commands are sent on the wire but their replies can't be matched back to a pending promise. The connection hangs silently until `socketTimeout` fires (or the load balancer kills the request).

## Fix

Allow `entry[1]` to be `null` in the filter, and preserve the entry as `{prefix, delimiter: null}` so callers can decide what to do with a non-hierarchical namespace. Normal namespace responses are unaffected.

## Tests

Two new cases added to `test/commands-integration-test.js`, inside the existing `NAMESPACE Command Tests` section:

1. **`namespace handles NIL delimiter (RFC 2342)`** — personal section contains one normal entry plus one NIL-delimiter entry. Asserts both parse, the NIL one surfaces with `delimiter: null`, and `connection.namespace` still resolves to the first valid entry.
2. **`namespace handles NIL delimiter as only personal entry`** — edge case where the only personal entry has NIL delimiter. Asserts the default-namespace fallback at the end of the NAMESPACE handler still produces a usable `connection.namespace`.

Both tests bail cleanly via `test.ok(false, …)` if the handler crashes, so a regression is recorded as a failed assertion rather than fatal-halting the whole nodeunit suite.

Local results:

| State | Result |
|---|---|
| `master` baseline | 2355/2355 pass |
| `master` + new tests, no fix | 2355/2357 pass — both new tests fail cleanly with the diagnostic message |
| `master` + new tests + fix | 2367/2367 pass |

## Test plan
- [x] `npx grunt nodeunit` passes
- [x] No existing tests modified or skipped
- [x] New tests verified to fail without the patch and pass with it