### PR TITLE
fix(folder): pass StatusObject value instead of its boolean primitive

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -222,7 +222,7 @@ const tools = {
                 existing.path = folder.path;
                 existing.subscribed = !!folder.subscribed;
                 existing.listed = !!folder.listed;
-                existing.status = !!folder.status;
+                existing.status = folder.status;
 
                 if (folder.specialUse) {
                     existing.specialUse = folder.specialUse;
@@ -242,7 +242,7 @@ const tools = {
                     path: folder.path,
                     subscribed: !!folder.subscribed,
                     listed: !!folder.listed,
-                    status: !!folder.status
+                    status: folder.status
                 };
 
                 if (folder.delimiter) {


### PR DESCRIPTION
The folder status property in e.g. `ListTreeResponse` from `client.listTree({ statusQuery: { unseen: true } })` will now be accessible.