### PR TITLE
feat(idle): make the auto-IDLE delay configurable

### DIFF
--- a/lib/imap-flow.d.ts
+++ b/lib/imap-flow.d.ts
@@ -30,6 +30,8 @@ export interface ImapFlowOptions {
     clientInfo?: IdInfoObject;
     /** If true, then do not start IDLE when connection is established */
     disableAutoIdle?: boolean;
+    /** How long (in ms) the connection has to be inactive before IDLE is started automatically.  Make it at least ca. 500ms or 1000ms, otherwise successive commands will be interleaved with a pointless IDLE, adding unnecessary round-trips and server load. Default: 15000 ms. */
+    autoIdleDelay?: number;
     /** Additional TLS options (see Node.js TLS documentation) */
     tls?: ConnectionOptions;
     /** Custom logger instance. Set to false to disable logging */

--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -188,6 +188,10 @@ class ImapFlow extends EventEmitter {
      * @property {Boolean} [disableAutoIdle=false]
      *     If `true`, do not start IDLE automatically. Useful when only specific operations are needed.
      *
+     * @property {Number} [autoIdleDelay=15000]
+     *     How long (in milliseconds) the connection has to be inactive before IDLE is started automatically.
+     *     Make it at least ca. 500ms or 1000ms, otherwise successive commands will be interleaved with a pointless IDLE, adding unnecessary round-trips and server load.
+     *
      * @property {Object} [tls]
      *     Additional TLS options. For details, see [Node.js TLS connect](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
      *
@@ -438,6 +442,7 @@ class ImapFlow extends EventEmitter {
         this.idRequested = false;
 
         this.maxIdleTime = this.options.maxIdleTime || false;
+        this.autoIdleDelay = typeof this.options.autoIdleDelay === 'number' ? this.options.autoIdleDelay : 15 * 1000;
         this.missingIdleCommand = (this.options.missingIdleCommand || '').toString().toUpperCase().trim() || 'NOOP';
 
         this.disableBinary = !!this.options.disableBinary;
@@ -2132,7 +2137,7 @@ class ImapFlow extends EventEmitter {
         }
         this.idleStartTimer = setTimeout(() => {
             this.idle().catch(err => this.log.warn({ err, cid: this.id }));
-        }, 15 * 1000);
+        }, this.autoIdleDelay);
         unrefTimer(this.idleStartTimer);
     }
 


### PR DESCRIPTION
Allow to change the delay for auto IDLE.

So far, it waited a hardcoded 15 seconds of connection inactivity before entering IDLE. The purpose is that a client which is actively issuing multiple successive commands does not enter and break IDLE around every single command.

For an interactive mail client, 15 seconds are too long, esp. when waiting for an email and clicking "Get mail". 2 seconds are more appropriate.